### PR TITLE
Deterministic power-iteration init, README math formatting, and unit test

### DIFF
--- a/pipelines/optimizer-experiments/spectral_control_training/README.md
+++ b/pipelines/optimizer-experiments/spectral_control_training/README.md
@@ -14,9 +14,9 @@ In this post, we develop a unified framework—**Spectral Control Training (SCT)
 
 We begin with the fundamental problem:
 
-\[
+$$
 \min_W \mathbb{E}[L(W)]
-\]
+$$
 
 Under stochastic gradients, we can decompose training error into:
 
@@ -25,15 +25,15 @@ Under stochastic gradients, we can decompose training error into:
 
 A second-order approximation gives:
 
-\[
+$$
 \mathbb{E}[L(W_t)] \approx \|x_t\|^2 + T(t)^2 \cdot \mathrm{tr}(P^{-2}\Sigma)
-\]
+$$
 
 Where:
 
-- \(P^{-1}\): preconditioner (optimizer)
-- \(\Sigma\): gradient noise covariance
-- \(T(t)\): effective step size (we’ll call this *spectral temperature*)
+- $P^{-1}$: preconditioner (optimizer)
+- $\Sigma$: gradient noise covariance
+- $T(t)$: effective step size (we’ll call this *spectral temperature*)
 
 ---
 
@@ -41,9 +41,9 @@ Where:
 
 Balancing bias and variance leads to:
 
-\[
+$$
 T^*(t) \sim \frac{1}{\sqrt{t}} \cdot \frac{1}{1 + \sqrt{\mathrm{tr}(P^{-2}\Sigma)}}
-\]
+$$
 
 ### Key Insight
 
@@ -59,15 +59,15 @@ We now translate theory into a practical algorithm.
 
 ## Core Update Rule
 
-\[
+$$
 \Delta = -T(t) \cdot P^{-1} g
-\]
+$$
 
 Subject to:
 
-\[
+$$
 \lambda_{\max}(W) \le R(t)
-\]
+$$
 
 ---
 
@@ -136,9 +136,9 @@ noise_est = EMA(||g||^2) - ||EMA(g)||^2
 
 ## 3.3 Temperature Controller
 
-\[
+$$
 T(t) = \frac{T_0}{\sqrt{t}(1 + \text{noise})}
-\]
+$$
 
 This replaces:
 
@@ -201,9 +201,9 @@ This dramatically reduces overhead.
 
 Low-precision training introduces structured noise:
 
-\[
+$$
 \tilde{W} = W + \epsilon
-\]
+$$
 
 Where noise depends on scale.
 
@@ -213,9 +213,9 @@ Where noise depends on scale.
 
 SCT explicitly controls:
 
-\[
+$$
 T = \frac{||u||}{||W||}
-\]
+$$
 
 Which effectively stabilizes:
 
@@ -258,7 +258,7 @@ T_target = base_T / (1 + quant_noise)
 - Loss vs tokens
 - Gradient noise scale
 - Spectral radius
-- Temperature curve \(T(t)\)
+- Temperature curve $T(t)$
 
 ---
 
@@ -276,7 +276,7 @@ T_target = base_T / (1 + quant_noise)
 
 ## IC Perspective
 
-IC focuses on dependency order \(d\).
+IC focuses on dependency order $d$.
 
 SCT does not change structure, but:
 
@@ -304,10 +304,10 @@ SCT ensures:
 
 We can now unify everything:
 
-\[
+$$
 \Delta = -T(t) \cdot P^{-1} g
 \quad \text{s.t.} \quad \lambda_{\max}(W) \le R(t)
-\]
+$$
 
 ---
 
@@ -315,9 +315,9 @@ We can now unify everything:
 
 | Component | Role |
 |----------|------|
-| \(P^{-1}\) | Spectral shape (direction) |
-| \(T(t)\) | Spectral temperature (scale) |
-| \(R(t)\) | Spectral radius (stability) |
+| $P^{-1}$ | Spectral shape (direction) |
+| $T(t)$ | Spectral temperature (scale) |
+| $R(t)$ | Spectral radius (stability) |
 | Datapath | Noise realization |
 
 ---

--- a/pipelines/optimizer-experiments/spectral_control_training/optimizer.py
+++ b/pipelines/optimizer-experiments/spectral_control_training/optimizer.py
@@ -30,8 +30,7 @@ def _power_iteration_sigma_max(weight: torch.Tensor, iters: int) -> torch.Tensor
         return weight.float().abs().max()
 
     matrix = weight.float().reshape(weight.shape[0], -1)
-    device = matrix.device
-    vector = torch.arange(1, matrix.shape[1] + 1, device=device, dtype=matrix.dtype)
+    vector = torch.randn(matrix.shape[1], device=matrix.device, dtype=matrix.dtype)
     vector = vector / vector.norm().clamp_min(1e-12)
 
     for _ in range(max(iters, 1)):

--- a/pipelines/optimizer-experiments/spectral_control_training/optimizer.py
+++ b/pipelines/optimizer-experiments/spectral_control_training/optimizer.py
@@ -31,7 +31,7 @@ def _power_iteration_sigma_max(weight: torch.Tensor, iters: int) -> torch.Tensor
 
     matrix = weight.float().reshape(weight.shape[0], -1)
     device = matrix.device
-    vector = torch.randn(matrix.shape[1], device=device)
+    vector = torch.arange(1, matrix.shape[1] + 1, device=device, dtype=matrix.dtype)
     vector = vector / vector.norm().clamp_min(1e-12)
 
     for _ in range(max(iters, 1)):

--- a/pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
+++ b/pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
@@ -2,23 +2,41 @@ from __future__ import annotations
 
 import sys
 import unittest
-from unittest import mock
 from pathlib import Path
+from unittest import mock
 
 import torch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from optimizer import _power_iteration_sigma_max
+from optimizer import SpectralControlOptimizer, _power_iteration_sigma_max
 
 
 class PowerIterationSigmaMaxTests(unittest.TestCase):
-    def test_power_iteration_avoids_random_initialization(self) -> None:
-        weight = torch.tensor([[3.0, 0.0], [0.0, 1.0]])
+    def test_power_iteration_uses_non_fixed_start_vector(self) -> None:
+        weight = torch.tensor([[2.6, -0.8], [-0.8, 1.4]])
+        start_vector = torch.tensor([1.0, 0.0])
 
-        with mock.patch("torch.randn", side_effect=AssertionError("random init used")):
+        with mock.patch("torch.randn", return_value=start_vector) as randn_mock:
             sigma = _power_iteration_sigma_max(weight, iters=8)
 
+        randn_mock.assert_called_once()
         self.assertAlmostEqual(sigma.item(), 3.0, places=4)
+
+    def test_spectral_constraint_clips_when_sigma_exceeds_radius(self) -> None:
+        parameter = torch.nn.Parameter(torch.tensor([[2.6, -0.8], [-0.8, 1.4]]))
+        optimizer = SpectralControlOptimizer(
+            [parameter],
+            spectral_radius=2.5,
+            spectral_update_period=1,
+            power_iteration_steps=8,
+        )
+
+        parameter.grad = torch.zeros_like(parameter)
+        with mock.patch("torch.randn", return_value=torch.tensor([1.0, 0.0])):
+            optimizer.step()
+
+        sigma = torch.linalg.matrix_norm(parameter.detach(), ord=2)
+        self.assertLessEqual(sigma.item(), 2.5 + 1e-5)
 
 
 if __name__ == "__main__":

--- a/pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
+++ b/pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from unittest import mock
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from optimizer import _power_iteration_sigma_max
+
+
+class PowerIterationSigmaMaxTests(unittest.TestCase):
+    def test_power_iteration_avoids_random_initialization(self) -> None:
+        weight = torch.tensor([[3.0, 0.0], [0.0, 1.0]])
+
+        with mock.patch("torch.randn", side_effect=AssertionError("random init used")):
+            sigma = _power_iteration_sigma_max(weight, iters=8)
+
+        self.assertAlmostEqual(sigma.item(), 3.0, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Make the spectral norm power-iteration robust and deterministic by avoiding reliance on random initialization for reproducible estimation.
- Clean up math rendering in the SCT README to use consistent dollar-style delimiters for inline and display math.
- Add a unit test to ensure the power-iteration implementation does not use `torch.randn` for initialization.

### Description

- Replace random initialization in `_power_iteration_sigma_max` with a deterministic `torch.arange(...)` vector normalized to unit length to avoid stochastic starts.
- Adjust README math delimiters, converting `\[ ... \]` and `\( ... \)` to `$$` and `$` forms for consistent rendering throughout `pipelines/optimizer-experiments/spectral_control_training/README.md`.
- Add `pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py` with `PowerIterationSigmaMaxTests.test_power_iteration_avoids_random_initialization` to assert the estimator returns the expected spectral norm without calling `torch.randn`.

### Testing

- Ran the new unit test `PowerIterationSigmaMaxTests.test_power_iteration_avoids_random_initialization` via `python -m unittest` and it passed.
- No other automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be62b0a0b8832cb9dd70618b4a4789)