### PR TITLE
Align SCT v2 optimizer with natural energy control

### DIFF
--- a/pipelines/optimizer-experiments/spectral_control_training/SCTv2.md
+++ b/pipelines/optimizer-experiments/spectral_control_training/SCTv2.md
@@ -9,9 +9,9 @@ A more precise formulation is:
 
 In this post, we present **Spectral Control Training v2 (SCT v2)**—a framework that unifies:
 
-* preconditioning (Adam/Muon)
-* noise-aware scheduling
-* spectral stability
+- preconditioning (Adam/Muon)
+- noise-aware scheduling
+- spectral stability
 
 into a **geometry-consistent control system**.
 
@@ -19,43 +19,39 @@ into a **geometry-consistent control system**.
 
 # 1. Theoretical Foundation: Optimization in Preconditioned Geometry
 
-Consider second-order approximation:
+Consider a second-order approximation:
 
-[
+```math
 L(\theta + \Delta) \approx L(\theta) + g^T \Delta + \frac{1}{2}\Delta^T H \Delta
-]
+```
 
-Ideal update:
+The ideal update is:
 
-[
+```math
 \Delta^* = -H^{-1} g
-]
+```
 
-In practice:
+In practice, we instead use:
 
-[
+```math
 \Delta = -P^{-1} g
-]
+```
 
-where (P) approximates curvature.
-
----
+where $P$ approximates curvature.
 
 ## Key Observation
 
-Optimization does not happen in Euclidean space, but in the geometry induced by (P).
+Optimization does not happen in Euclidean space, but in the geometry induced by $P$.
 
 Define the **natural metric**:
 
-[
-||g||_{P^{-1}}^2 = g^T P^{-1} g
-]
+```math
+\lVert g \rVert_{P^{-1}}^2 = g^T P^{-1} g
+```
 
----
+## Core Insight
 
-## 🔥 Core Insight
-
-> **The correct notion of “step size” is not (||\Delta||), but (g^T P^{-1} g).**
+> **The correct notion of “step size” is not $\lVert\Delta\rVert$, but $g^T P^{-1} g$.**
 
 ---
 
@@ -63,13 +59,11 @@ Define the **natural metric**:
 
 We define the update:
 
-[
+```math
 \Delta = -\alpha_t \cdot P^{-1} g
-]
+```
 
-where (\alpha_t) is chosen to control the **natural gradient energy**.
-
----
+where $\alpha_t$ is chosen to control the **natural gradient energy**.
 
 ## Algorithm
 
@@ -77,7 +71,6 @@ where (\alpha_t) is chosen to control the **natural gradient energy**.
 # SCT v2
 
 for step t:
-
     g = grad(W)
 
     # Preconditioner (Adam / Muon / etc.)
@@ -90,7 +83,7 @@ for step t:
     T_target = schedule(t, noise_est)
 
     # Scale update
-    u *= (T_target / (T_current + eps))
+    u *= T_target / (T_current + eps)
 
     # Apply update
     W -= u
@@ -99,7 +92,7 @@ for step t:
     if step % k == 0:
         sigma = estimate_sigma_max(W)
         if sigma > R(t):
-            W *= (R(t) / sigma)
+            W *= R(t) / sigma
 ```
 
 ---
@@ -114,21 +107,17 @@ for step t:
 | AdamW       | Diagonal metric   |
 | Muon / SOAP | Structured metric |
 
----
-
 ## 3.2 Natural Energy (Key Variable)
 
-[
+```math
 T = \sqrt{g^T P^{-1} g}
-]
+```
 
 This replaces:
 
-* learning rate
-* ||ΔW|| heuristics
-* Hyperball scaling
-
----
+- learning rate
+- $\lVert\Delta W\rVert$ heuristics
+- Hyperball scaling
 
 ## 3.3 Noise Estimator
 
@@ -136,17 +125,13 @@ This replaces:
 noise_est = EMA(||g||^2) - ||EMA(g)||^2
 ```
 
----
-
 ## 3.4 Temperature Schedule
 
-[
+```math
 T(t) = \frac{T_0}{\sqrt{t}} \cdot \frac{1}{1 + \text{noise}}
-]
+```
 
----
-
-## 🔥 Interpretation
+## Interpretation
 
 > We are controlling **energy injected into the system**, not raw parameter movement.
 
@@ -162,23 +147,19 @@ We need global reductions:
 T_current = all_reduce(sum(g * u))
 ```
 
----
-
 ## 4.2 Efficient Implementation
 
 Reuse optimizer state:
 
-* (u = m / \sqrt{v})
-* compute (g \cdot u) cheaply
-
----
+- $u = m / \sqrt{v}$
+- compute $g \cdot u$ cheaply
 
 ## 4.3 No Extra Instability
 
 Unlike Hyperball:
 
-* no explicit normalization of (u)
-* only scaling
+- no explicit normalization of $u$
+- only scaling
 
 ---
 
@@ -186,25 +167,21 @@ Unlike Hyperball:
 
 Low precision introduces noise:
 
-[
+```math
 g \rightarrow g + \epsilon
-]
-
----
+```
 
 ## SCT v2 Advantage
 
-Controls:
+SCT v2 controls:
 
-[
+```math
 g^T P^{-1} g
-]
+```
 
 This ensures:
 
 > **update energy remains stable under quantization noise**
-
----
 
 ## Adaptive Schedule
 
@@ -218,22 +195,18 @@ T_target = base_T / (1 + quant_noise)
 
 ## Baselines
 
-* AdamW
-* Muon
-* Hyperball
-* SSO
-* SCT v2
-
----
+- AdamW
+- Muon
+- Hyperball
+- SSO
+- SCT v2
 
 ## Metrics
 
-* loss vs tokens
-* gradient noise scale
-* natural step size (g^T P^{-1} g)
-* spectral norm
-
----
+- loss vs tokens
+- gradient noise scale
+- natural step size $g^T P^{-1} g$
+- spectral norm
 
 ## Expected Results
 
@@ -256,20 +229,21 @@ SCT v2 improves:
 
 Equivalent to:
 
-* reducing effective noise dimension
-* improving information flow
+- reducing effective noise dimension
+- improving information flow
+
 
 ---
 
 ## GDN Perspective
 
-* updates = operators
-* stability depends on spectrum
+- updates = operators
+- stability depends on spectrum
 
 SCT v2 ensures:
 
-* controlled update energy
-* stable operator dynamics
+- controlled update energy
+- stable operator dynamics
 
 ---
 
@@ -277,28 +251,25 @@ SCT v2 ensures:
 
 We now unify training as:
 
-[
-\Delta = -\alpha_t \cdot P^{-1} g
-\quad \text{s.t.} \quad \lambda_{\max}(W) \le R(t)
-]
-
----
+```math
+\Delta = -lpha_t \cdot P^{-1} g
+\quad 	ext{s.t.} \quad \lambda_{\max}(W) \le R(t)
+```
 
 ## Components
 
 | Element        | Role      |
 | -------------- | --------- |
-| (P^{-1})       | geometry  |
-| (g^T P^{-1} g) | energy    |
-| (T(t))         | control   |
-| (R(t))         | stability |
+| $P^{-1}$       | geometry  |
+| $g^T P^{-1} g$ | energy    |
+| $T(t)$         | control   |
+| $R(t)$         | stability |
 
----
+## Final Insight
 
-## 🔥 Final Insight
-
-> **Optimization is not about moving parameters.
-> It is about controlling energy in a curved space.**
+> **Optimization is not about moving parameters.**
+>
+> **It is about controlling energy in a curved space.**
 
 ---
 
@@ -306,45 +277,46 @@ We now unify training as:
 
 ### Optimization and Preconditioning
 
-* Kingma & Ba. *Adam: A Method for Stochastic Optimization* (2014)
-* Loshchilov & Hutter. *Decoupled Weight Decay Regularization* (2017)
-* Martens. *Hessian-Free Optimization* (2010)
-* Grosse & Martens. *K-FAC* (2016)
+- Kingma & Ba. *Adam: A Method for Stochastic Optimization* (2014)
+- Loshchilov & Hutter. *Decoupled Weight Decay Regularization* (2017)
+- Martens. *Hessian-Free Optimization* (2010)
+- Grosse & Martens. *K-FAC* (2016)
 
 ---
 
 ### Noise and Scaling
 
-* Smith et al. *Don’t Decay the Learning Rate, Increase the Batch Size* (2017)
-* Smith & Dherin. *On the Origin of Implicit Regularization in SGD* (2020)
-* Kaplan et al. *Scaling Laws for Neural Language Models* (2020)
-* Hoffmann et al. *Chinchilla* (2022)
+- Smith et al. *Don’t Decay the Learning Rate, Increase the Batch Size* (2017)
+- Smith & Dherin. *On the Origin of Implicit Regularization in SGD* (2020)
+- Kaplan et al. *Scaling Laws for Neural Language Models* (2020)
+- Hoffmann et al. *Chinchilla* (2022)
 
 ---
 
 ### Spectral Methods
 
-* Trefethen & Bau. *Numerical Linear Algebra*
-* Golub & Van Loan. *Matrix Computations*
-* Saad. *Iterative Methods for Sparse Linear Systems*
+- Trefethen & Bau. *Numerical Linear Algebra*
+- Golub & Van Loan. *Matrix Computations*
+- Saad. *Iterative Methods for Sparse Linear Systems*
 
 ---
 
 ### Spectral Stability
 
-* Miyato et al. *Spectral Normalization for GANs* (2018)
+- Miyato et al. *Spectral Normalization for GANs* (2018)
 
 ---
 
 ### Weight Decay / Hyperball
 
-* [https://whenwen.github.io/wd_blog/public/weight-decay-part-2.html](https://whenwen.github.io/wd_blog/public/weight-decay-part-2.html)
+- <https://whenwen.github.io/wd_blog/public/weight-decay-part-2.html>
 
 ---
 
-# 🎯 Closing
+# Closing
 
 > SCT v2 is not a tweak to Adam.
+>
 > It is a shift from **parameter-space heuristics → geometry-consistent control**.
 
 ---

--- a/pipelines/optimizer-experiments/spectral_control_training/optimizer.py
+++ b/pipelines/optimizer-experiments/spectral_control_training/optimizer.py
@@ -15,10 +15,10 @@ def _distributed_sum(value: torch.Tensor) -> torch.Tensor:
     return value
 
 
-def _global_l2_norm_sq(tensors: Iterable[torch.Tensor]) -> torch.Tensor:
+def _global_sum(tensors: Iterable[torch.Tensor]) -> torch.Tensor:
     total = None
     for tensor in tensors:
-        contribution = tensor.float().pow(2).sum()
+        contribution = tensor.float().sum()
         total = contribution if total is None else total + contribution
     if total is None:
         total = torch.tensor(0.0)
@@ -44,14 +44,14 @@ def _power_iteration_sigma_max(weight: torch.Tensor, iters: int) -> torch.Tensor
 
 
 class SpectralControlOptimizer(Optimizer):
-    """Minimal PyTorch implementation of Spectral Control Training (SCT).
+    """PyTorch implementation of Spectral Control Training v2 (SCT v2).
 
-    This implementation follows the shared design verbatim:
+    The optimizer follows the SCT v2 control loop:
     1. precondition gradients,
-    2. estimate noise,
-    3. compute a temperature target,
-    4. rescale the update in closed loop,
-    5. optionally enforce a spectral constraint.
+    2. estimate gradient noise,
+    3. measure natural gradient energy sqrt(g^T P^-1 g),
+    4. scale updates to a target energy schedule,
+    5. optionally enforce a spectral radius constraint.
     """
 
     def __init__(
@@ -100,7 +100,7 @@ class SpectralControlOptimizer(Optimizer):
             with torch.enable_grad():
                 loss = closure()
 
-        updates: list[tuple[torch.nn.Parameter, torch.Tensor, dict, dict]] = []
+        updates: list[tuple[torch.nn.Parameter, torch.Tensor, torch.Tensor, dict, dict]] = []
 
         for group in self.param_groups:
             beta2 = group["beta2"]
@@ -123,6 +123,7 @@ class SpectralControlOptimizer(Optimizer):
                     state["grad_ema"] = torch.zeros_like(param)
                     state["noise_ema"] = torch.zeros((), device=param.device)
                     state["temperature"] = torch.zeros((), device=param.device)
+                    state["natural_energy"] = torch.zeros((), device=param.device)
 
                 exp_avg_sq = state["exp_avg_sq"]
                 grad_ema = state["grad_ema"]
@@ -130,7 +131,7 @@ class SpectralControlOptimizer(Optimizer):
                 exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
                 grad_ema.mul_(noise_beta).add_(grad, alpha=1 - noise_beta)
 
-                preconditioned = grad / exp_avg_sq.sqrt().add_(eps)
+                preconditioned = grad / exp_avg_sq.sqrt().add(eps)
                 noise_instant = grad.float().pow(2).sum() - grad_ema.float().pow(2).sum()
                 noise_instant = noise_instant.clamp_min(0.0)
                 state["noise_ema"].mul_(noise_beta).add_(
@@ -138,33 +139,35 @@ class SpectralControlOptimizer(Optimizer):
                 )
 
                 state["step"] += 1
-                updates.append((param, preconditioned, state, group))
+                updates.append((param, grad, preconditioned, state, group))
 
         if not updates:
             return loss
 
-        weight_norm_sq = _global_l2_norm_sq(param.data for param, _, _, _ in updates)
-        update_norm_sq = _global_l2_norm_sq(update for _, update, _, _ in updates)
-        weight_norm = weight_norm_sq.sqrt().clamp_min(1e-12)
-        update_norm = update_norm_sq.sqrt().clamp_min(1e-12)
-        current_temperature = update_norm / weight_norm
+        natural_energy_sq = _global_sum(
+            grad.float().mul(update.float()) for _, grad, update, _, _ in updates
+        ).clamp_min_(0.0)
+        current_temperature = natural_energy_sq.sqrt().clamp_min(1e-12)
+        mean_noise = (
+            _global_sum(state["noise_ema"] for _, _, _, state, _ in updates) / len(updates)
+        )
 
-        mean_noise = torch.stack([state["noise_ema"] for _, _, state, _ in updates]).mean()
-
-        for param, update, state, group in updates:
+        for param, _, update, state, group in updates:
             step = state["step"]
             target_temperature = (group["T0"] / math.sqrt(step)) / (1.0 + mean_noise.item())
             temperature_scale = target_temperature / current_temperature.item()
-            scaled_update = update * temperature_scale
-            param.add_(scaled_update, alpha=-1.0)
+            param.add_(update, alpha=-temperature_scale)
             state["temperature"] = torch.tensor(target_temperature, device=param.device)
+            state["natural_energy"] = torch.tensor(
+                current_temperature.item(), device=param.device
+            )
 
         self._apply_spectral_constraint(updates)
         return loss
 
     @torch.no_grad()
     def _apply_spectral_constraint(self, updates):
-        for param, _, state, group in updates:
+        for param, _, _, state, group in updates:
             spectral_radius = group["spectral_radius"]
             if spectral_radius is None:
                 continue
@@ -174,7 +177,9 @@ class SpectralControlOptimizer(Optimizer):
             if step % period != 0:
                 continue
 
-            radius_target = spectral_radius(step) if callable(spectral_radius) else spectral_radius
+            radius_target = (
+                spectral_radius(step) if callable(spectral_radius) else spectral_radius
+            )
             sigma = _power_iteration_sigma_max(param.data, group["power_iteration_steps"])
             if sigma > radius_target:
                 param.mul_(radius_target / sigma)

--- a/pipelines/optimizer-experiments/spectral_control_training/optimizer.py
+++ b/pipelines/optimizer-experiments/spectral_control_training/optimizer.py
@@ -15,6 +15,13 @@ def _distributed_sum(value: torch.Tensor) -> torch.Tensor:
     return value
 
 
+def _distributed_mean(value: torch.Tensor) -> torch.Tensor:
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(value, op=dist.ReduceOp.SUM)
+        value.div_(dist.get_world_size())
+    return value
+
+
 def _global_sum(tensors: Iterable[torch.Tensor]) -> torch.Tensor:
     total = None
     for tensor in tensors:
@@ -144,11 +151,11 @@ class SpectralControlOptimizer(Optimizer):
         if not updates:
             return loss
 
-        natural_energy_sq = _global_sum(
-            grad.float().mul(update.float()) for _, grad, update, _, _ in updates
+        natural_energy_sq = _distributed_mean(
+            _global_sum(grad.float().mul(update.float()) for _, grad, update, _, _ in updates)
         ).clamp_min_(0.0)
         current_temperature = natural_energy_sq.sqrt().clamp_min(1e-12)
-        mean_noise = (
+        mean_noise = _distributed_mean(
             _global_sum(state["noise_ema"] for _, _, _, state, _ in updates) / len(updates)
         )
 

--- a/pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
+++ b/pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
@@ -40,6 +40,36 @@ class SpectralControlOptimizerTests(unittest.TestCase):
             places=6,
         )
 
+    def test_step_averages_replicated_distributed_statistics(self) -> None:
+        param = torch.nn.Parameter(torch.tensor([2.0]))
+        optimizer = SpectralControlOptimizer([param], T0=0.5, beta2=0.0, noise_beta=0.5)
+        param.grad = torch.tensor([4.0])
+
+        world_size = 4
+
+        def fake_all_reduce(tensor: torch.Tensor, op=None) -> None:
+            tensor.mul_(world_size)
+
+        with (
+            mock.patch("torch.distributed.is_available", return_value=True),
+            mock.patch("torch.distributed.is_initialized", return_value=True),
+            mock.patch("torch.distributed.get_world_size", return_value=world_size),
+            mock.patch("torch.distributed.all_reduce", side_effect=fake_all_reduce),
+        ):
+            optimizer.step()
+
+        self.assertAlmostEqual(param.item(), 1.5, places=6)
+        self.assertAlmostEqual(
+            optimizer.state[param]["temperature"].item(),
+            0.5 / (1.0 + 6.0),
+            places=6,
+        )
+        self.assertAlmostEqual(
+            optimizer.state[param]["natural_energy"].item(),
+            math.sqrt(4.0),
+            places=6,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
+++ b/pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import math
 import unittest
 from unittest import mock
 
 import torch
 
-from optimizer import _power_iteration_sigma_max
+from optimizer import SpectralControlOptimizer, _power_iteration_sigma_max
 
 
 class PowerIterationSigmaMaxTests(unittest.TestCase):
@@ -16,6 +17,28 @@ class PowerIterationSigmaMaxTests(unittest.TestCase):
             sigma = _power_iteration_sigma_max(weight, iters=8)
 
         self.assertAlmostEqual(sigma.item(), 3.0, places=4)
+
+
+class SpectralControlOptimizerTests(unittest.TestCase):
+    def test_step_scales_by_natural_energy(self) -> None:
+        param = torch.nn.Parameter(torch.tensor([2.0]))
+        optimizer = SpectralControlOptimizer([param], T0=0.5, beta2=0.0, noise_beta=0.0)
+        param.grad = torch.tensor([4.0])
+
+        optimizer.step()
+
+        expected_update = 0.5
+        self.assertAlmostEqual(param.item(), 2.0 - expected_update, places=6)
+        self.assertAlmostEqual(
+            optimizer.state[param]["temperature"].item(),
+            0.5,
+            places=6,
+        )
+        self.assertAlmostEqual(
+            optimizer.state[param]["natural_energy"].item(),
+            math.sqrt(4.0),
+            places=6,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the PyTorch SCT optimizer to scale updates by SCT v2 natural energy `sqrt(g^T P^-1 g)` instead of the prior norm ratio
- keep the lightweight optimizer test coverage aligned with the new control loop and tracked optimizer state
- rewrite `SCTv2.md` math blocks and inline symbols so equations render correctly on GitHub

## Testing
- python -m py_compile pipelines/optimizer-experiments/spectral_control_training/optimizer.py pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py
- python -m unittest pipelines/optimizer-experiments/spectral_control_training/test_optimizer.py *(fails in this environment because `torch` is not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0b70c1200832c8cb4313bd7566acf)